### PR TITLE
Tolérance aux erreurs : handle client crash and disconnection on server

### DIFF
--- a/src/server/include/UdpServer.hpp
+++ b/src/server/include/UdpServer.hpp
@@ -23,6 +23,8 @@ class UdpServer {
     void handlePacket(const asio::ip::udp::endpoint& from, const char* data, std::size_t size);
     void gameLoop();
     void broadcastState();
+    void checkTimeouts();
+    void removeClient(const std::string& key);
 
     asio::io_context io_;
     asio::ip::udp::socket socket_;
@@ -39,6 +41,8 @@ class UdpServer {
     // ECS registry holds all entities/components
     rt::ecs::Registry reg_;
     std::mt19937 rng_;
+    std::unordered_map<std::string,
+    std::chrono::steady_clock::time_point> lastSeen_;
 };
 
 }


### PR DESCRIPTION
The server can now detect when a client disconnects or crashes, cleanly remove them from the game world, and continue running without interruption.

🧩 Changes

Added lastSeen_ map in UdpServer to record the timestamp of the last packet received per client.

- Added checkTimeouts() and removeClient() helpers.

- Integrated timeout checking in the main gameLoop().

- Removed inactive clients (after 10 seconds of silence).
