### PR TITLE
Feature/waiting screen

### DIFF
--- a/src/client/include/client/ui/Screens.hpp
+++ b/src/client/include/client/ui/Screens.hpp
@@ -11,7 +11,7 @@ enum class ScreenState {
     Menu,
     Singleplayer,
     Multiplayer,
-    Waiting, // new waiting screen until enough players are connected
+    Waiting,
     Gameplay,
     Options,
     Leaderboard,
@@ -33,7 +33,7 @@ public:
     void drawMenu(ScreenState& screen);
     void drawSingleplayer(ScreenState& screen, SingleplayerForm& form);
     void drawMultiplayer(ScreenState& screen, MultiplayerForm& form);
-    void drawWaiting(ScreenState& screen); // new draw method for waiting screen
+    void drawWaiting(ScreenState& screen);
     void drawGameplay(ScreenState& screen);
     void drawOptions();
     void drawLeaderboard();

--- a/src/client/src/ui/App.cpp
+++ b/src/client/src/ui/App.cpp
@@ -42,7 +42,7 @@ void App::run() {
             case ScreenState::Menu: _screens.drawMenu(_screen); break;
             case ScreenState::Singleplayer: _screens.drawSingleplayer(_screen, _singleForm); break;
             case ScreenState::Multiplayer: _screens.drawMultiplayer(_screen, _form); break;
-            case ScreenState::Waiting: _screens.drawWaiting(_screen); break; // new waiting screen
+            case ScreenState::Waiting: _screens.drawWaiting(_screen); break;
             case ScreenState::Gameplay:
                 if (!_resizedForGameplay) {
                     SetWindowSize(screenWidth * 1, screenHeight * 1);

--- a/src/client/src/ui/Screens.cpp
+++ b/src/client/src/ui/Screens.cpp
@@ -158,7 +158,7 @@ void Screens::drawMultiplayer(ScreenState& screen, MultiplayerForm& form) {
                 if (ok) {
                     _statusMessage = std::string("Player Connected.");
                     _connected = true;
-                    screen = ScreenState::Waiting; // Change to Waiting state
+                    screen = ScreenState::Waiting;
                 } else {
                     _statusMessage = std::string("Connection failed.");
                     teardownNet();
@@ -277,7 +277,7 @@ void Screens::drawWaiting(ScreenState& screen) {
     // Count players in the latest world snapshot
     int playerCount = 0;
     for (const auto& e : _entities) {
-        if (e.type == 1) // Player
+        if (e.type == 1)
             ++playerCount;
     }
 
@@ -287,7 +287,7 @@ void Screens::drawWaiting(ScreenState& screen) {
     titleCentered(sub.c_str(), (int)(h * 0.40f), baseFont, RAYWHITE);
 
     // Simple animated dots
-    int dots = ((int)(GetTime() * 2)) % 4; // 0..3
+    int dots = ((int)(GetTime() * 2)) % 4;
     std::string hint = "The game will start automatically" + std::string(dots, '.');
     titleCentered(hint.c_str(), (int)(h * 0.50f), baseFont, LIGHTGRAY);
 


### PR DESCRIPTION
This pull request introduces a new "Waiting" screen to the multiplayer flow, improving the user experience by providing feedback while waiting for all players to connect before starting the game. The most important changes are grouped below by theme.

**Multiplayer flow and UI improvements:**

* Added a new `ScreenState::Waiting` enum value to represent the waiting state in the screen flow.
* Implemented the `Screens::drawWaiting` method, which displays a waiting screen, shows the number of connected players, includes an animated hint, and provides a cancel button. The screen automatically transitions to gameplay when enough players are present.
* Updated the multiplayer connection logic so that, after a successful connection, the screen transitions to the new "Waiting" state instead of directly to gameplay.
* Integrated the new waiting screen into the main application loop by handling the `ScreenState::Waiting` case and invoking the appropriate draw method.
* Declared the new `drawWaiting` method in the `Screens` class interface.